### PR TITLE
use 0.5.0 API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,8 @@ getrandom = { version = "0.2", features = ["js"] }
 js-sys = "0.3"
 
 leaflet = { path = "./leaflet" }
-leptos = { version = "0.5.0-beta", default-features = false }
-leptos_meta = { version = "0.5.0-beta", default-features = false }
+leptos = { version = "0.5.0", default-features = false }
+leptos_meta = { version = "0.5.0", default-features = false }
 
 paste = "1.0"
 rand = "0.8"

--- a/examples/with-server/src/app.rs
+++ b/examples/with-server/src/app.rs
@@ -1,4 +1,5 @@
 use leptos::*;
+use leptos::logging::log;
 use leptos_leaflet::leaflet::{LocationEvent, Map};
 use leptos_leaflet::*;
 use leptos_meta::*;

--- a/leptos-leaflet/src/components/image_overlay.rs
+++ b/leptos-leaflet/src/components/image_overlay.rs
@@ -1,5 +1,7 @@
 use crate::components::context::LeafletMapContext;
 use leptos::*;
+use leptos::logging::log;
+
 
 #[component(transparent)]
 pub fn ImageOverlay(

--- a/leptos-leaflet/src/components/video_overlay.rs
+++ b/leptos-leaflet/src/components/video_overlay.rs
@@ -1,5 +1,6 @@
 use crate::components::context::LeafletMapContext;
 use leptos::*;
+use leptos::logging::log;
 
 #[component(transparent)]
 pub fn VideoOverlay(


### PR DESCRIPTION
The `log` macro was moved into its own module. This PR explicitly imports `leptos::logging::log`. 