### PR TITLE
fix: Removed unit type in empty view macro call in TileLayerWms

### DIFF
--- a/leptos-leaflet/src/components/tile_layer_wms.rs
+++ b/leptos-leaflet/src/components/tile_layer_wms.rs
@@ -25,7 +25,7 @@ pub fn TileLayerWms(
             });
         }
     });
-    children.map_or(view! { <>()</> }, |c| view! { <>{ c() }</>})
+    children.map_or(view! { <>""</> }, |c| view! { <>{ c() }</>})
 }
 
 #[component(transparent)]


### PR DESCRIPTION
The unit type has been rendered. This should not occur.