### PR TITLE
Fix and change suggestions for circle, tooltip and tile layer component

### DIFF
--- a/leptos-leaflet/src/components/circle.rs
+++ b/leptos-leaflet/src/components/circle.rs
@@ -4,7 +4,7 @@ use crate::components::position::Position;
 use crate::core::LeafletMaybeSignal;
 use crate::{
     setup_layer_leaflet_option, setup_layer_leaflet_option_ref, LayerEvents, MouseEvents,
-    PopupEvents, TooltipEvents,
+    PopupEvents, TooltipEvents, MoveEvents,
 };
 use leaflet::CircleOptions;
 use leptos::*;
@@ -31,10 +31,12 @@ pub fn Circle(
     #[prop(into, optional)] layer_events: LayerEvents,
     #[prop(into, optional)] popup_events: PopupEvents,
     #[prop(into, optional)] tooltip_events: TooltipEvents,
+    #[prop(into, optional)] move_events: MoveEvents,
 
     #[prop(into)] radius: MaybeSignal<f64>,
     #[prop(optional)] children: Option<Children>,
 ) -> impl IntoView {
+    let position_tracking = center;
     let overlay_context = extend_context_with_overlay();
     let overlay = store_value(None::<leaflet::Circle>);
 
@@ -68,6 +70,7 @@ pub fn Circle(
             popup_events.setup(&circle);
             tooltip_events.setup(&circle);
             layer_events.setup(&circle);
+            move_events.setup(&circle);
 
             circle.add_to(&map);
             overlay_context.set_container(&circle);
@@ -157,7 +160,18 @@ pub fn Circle(
         false,
     );
 
+    let position_stop = watch(
+        move || position_tracking.get(),
+        move |position_tracking, _, _| {
+            if let Some(circle) = overlay.get_value() {
+                circle.set_lat_lng(&position_tracking.into());
+            }
+        },
+        false,
+    );     
+
     on_cleanup(move || {
+        position_stop();
         radius_stop();
         stroke_stop();
         color_stop();

--- a/leptos-leaflet/src/components/circle.rs
+++ b/leptos-leaflet/src/components/circle.rs
@@ -65,6 +65,8 @@ pub fn Circle(
             setup_layer_leaflet_option_ref!(class_name, options);
             let circle =
                 leaflet::Circle::new_with_options(&center.get_untracked().into(), &options);
+            
+            leaflet::Circle::set_radius(&circle, radius.get_untracked());
 
             mouse_events.setup(&circle);
             popup_events.setup(&circle);

--- a/leptos-leaflet/src/components/tile_layer.rs
+++ b/leptos-leaflet/src/components/tile_layer.rs
@@ -12,7 +12,7 @@ pub fn TileLayer(
     create_effect(move |_| {
         if let Some(map) = map_context.map() {
             let options = leaflet::TileLayerOptions::default();
-            if attribution.is_empty() {
+            if !attribution.is_empty() {
                 options.set_attribution(attribution.to_string());
             }
             let map_layer = leaflet::TileLayer::new_options(&url, &options);

--- a/leptos-leaflet/src/components/tooltip.rs
+++ b/leptos-leaflet/src/components/tooltip.rs
@@ -11,6 +11,7 @@ pub fn Tooltip(
     #[prop(into, optional)] permanent: MaybeSignal<bool>,
     #[prop(into, optional, default="auto".into())] direction: MaybeSignal<String>,
     #[prop(into, optional)] sticky: MaybeSignal<bool>,
+    #[prop(into, optional, default=0.9.into())] opacity: MaybeSignal<f64>,
     children: Children,
 ) -> impl IntoView {
     let map_context = use_context::<LeafletMapContext>().expect("Map context not found");
@@ -23,6 +24,7 @@ pub fn Tooltip(
         options.set_permanent(permanent.get_untracked());
         options.set_direction(direction.get_untracked());
         options.set_sticky(sticky.get_untracked());
+        options.set_opacity(opacity.get_untracked());
 
         if let Some(overlay_context) = overlay_context {
             if let (Some(layer), Some(_map)) = (


### PR DESCRIPTION
**1. Fix radius property of the circle component**
The circle component has a radius property that was never set. 
<BR />

**2. Add move event to the circle component**
By adding a Move event, the circle object can be repositioned on the map.
<BR />

**3. Fix tile layer attribution property**
`` !`` logical operator was missing from the condition.

```
            if !attribution.is_empty() {
                options.set_attribution(attribution.to_string());
            }
```
<BR />

**4. Add opacity property to the tooltip**
A new opacity property for the tooltip component.
<BR />
<BR />
<BR />

**Let's do IT better**