### PR TITLE
Use serde-wasm-bindgen instead of serde-serialize

### DIFF
--- a/examples/simple-map/Cargo.lock
+++ b/examples/simple-map/Cargo.lock
@@ -548,6 +548,7 @@ dependencies = [
  "paste",
  "rand",
  "regex",
+ "serde-wasm-bindgen",
  "wasm-bindgen",
  "web-sys",
 ]
@@ -1419,8 +1420,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1223296a201415c7fad14792dbefaace9bd52b62d33453ade1c5b5f07555406"
 dependencies = [
  "cfg-if",
- "serde",
- "serde_json",
  "wasm-bindgen-macro",
 ]
 

--- a/examples/tilelayerwms/Cargo.lock
+++ b/examples/tilelayerwms/Cargo.lock
@@ -737,6 +737,7 @@ dependencies = [
  "paste",
  "rand",
  "regex",
+ "serde-wasm-bindgen",
  "wasm-bindgen",
  "web-sys",
 ]
@@ -1684,8 +1685,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1223296a201415c7fad14792dbefaace9bd52b62d33453ade1c5b5f07555406"
 dependencies = [
  "cfg-if",
- "serde",
- "serde_json",
  "wasm-bindgen-macro",
 ]
 

--- a/examples/with-server/Cargo.lock
+++ b/examples/with-server/Cargo.lock
@@ -939,6 +939,7 @@ dependencies = [
  "paste",
  "rand",
  "regex",
+ "serde-wasm-bindgen",
  "wasm-bindgen",
  "web-sys",
 ]
@@ -2247,8 +2248,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1223296a201415c7fad14792dbefaace9bd52b62d33453ade1c5b5f07555406"
 dependencies = [
  "cfg-if",
- "serde",
- "serde_json",
  "wasm-bindgen-macro",
 ]
 

--- a/leptos-leaflet/Cargo.toml
+++ b/leptos-leaflet/Cargo.toml
@@ -20,7 +20,8 @@ paste = "1.0"
 rand = "0.8"
 regex = "1.9"
 
-wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
+wasm-bindgen = "0.2"
+serde-wasm-bindgen = "0.6"
 web-sys = { version = "0.3", features = [
     "console",
     "HtmlElement",


### PR DESCRIPTION
This updates the project to use `serde-wasm-bindgen` instead of the `serde-serialize` feature of `wasm-bindgen` in order to avoid a potential cyclic dependency issue. Please see #24 for additional details.