### PR TITLE
regex package removed, fixed image and video overlay and made them public

### DIFF
--- a/leptos-leaflet/Cargo.toml
+++ b/leptos-leaflet/Cargo.toml
@@ -18,7 +18,6 @@ leptos_meta = { version = "0.6", default-features = false }
 
 paste = "1.0"
 rand = "0.8"
-regex = "1.9"
 
 wasm-bindgen = "0.2"
 serde-wasm-bindgen = "0.6"

--- a/leptos-leaflet/src/components/bounds.rs
+++ b/leptos-leaflet/src/components/bounds.rs
@@ -1,0 +1,129 @@
+use crate::Position;
+use leaflet::LatLng;
+use leaflet::LatLngBounds;
+
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
+pub struct Bounds {
+    pub ne_corner: Position,
+    pub sw_corner: Position,
+}
+
+impl Bounds {
+    pub fn new(ne_corner: Position, sw_corner: Position) -> Self {
+        Self {
+            ne_corner: ne_corner,
+            sw_corner: sw_corner,
+        }
+    }
+
+    pub fn get_center(&self) -> Position {
+        Position {
+            lat: (self.ne_corner.lat + self.sw_corner.lat) / 2.0,
+            lng: (self.ne_corner.lng + self.sw_corner.lng) / 2.0,
+        }
+    }
+
+    pub fn get_bottom_left(&self) -> Position {
+        Position::new(self.sw_corner.lat, self.sw_corner.lng)
+    }
+
+    pub fn get_top_right(&self) -> Position {
+        Position::new(self.ne_corner.lat, self.ne_corner.lng)
+    }
+
+    pub fn get_top_left(&self) -> Position {
+        Position::new(self.ne_corner.lat, self.sw_corner.lng)
+    }
+
+    pub fn get_bottom_right(&self) -> Position {
+        Position::new(self.sw_corner.lat, self.ne_corner.lng)
+    }
+
+    pub fn get_size(&self) -> Position {
+        Position {
+            lat: (self.ne_corner.lat - self.sw_corner.lat).abs(),
+            lng: (self.ne_corner.lng - self.sw_corner.lng).abs(),
+        }
+    }
+
+    pub fn contains(&self, position: Position) -> bool {
+        self.sw_corner.lat <= position.lat
+            && self.ne_corner.lat >= position.lat
+            && self.sw_corner.lng <= position.lng
+            && self.ne_corner.lng >= position.lng
+    }
+
+    // Returns true if the rectangle intersects the given bounds. Two bounds intersect if they have at least one point in common.
+    pub fn intersects(&self, other: Bounds) -> bool {
+        let lat_overlap = (self.ne_corner.lat >= other.sw_corner.lat
+            && self.sw_corner.lat <= other.ne_corner.lat)
+            || (other.ne_corner.lat >= self.sw_corner.lat
+                && other.sw_corner.lat <= self.ne_corner.lat);
+        let lng_overlap = (self.ne_corner.lng >= other.sw_corner.lng
+            && self.sw_corner.lng <= other.ne_corner.lng)
+            || (other.ne_corner.lng >= self.sw_corner.lng
+                && other.sw_corner.lng <= self.ne_corner.lng);
+
+        lat_overlap && lng_overlap
+    }
+
+    // Returns true if the rectangle overlaps the given bounds. Two bounds overlap if their intersection is an area.
+    pub fn overlaps(&self, other: Bounds) -> bool {
+        let lat_overlap = (self.ne_corner.lat > other.sw_corner.lat
+            && self.sw_corner.lat < other.ne_corner.lat)
+            || (other.ne_corner.lat > self.sw_corner.lat
+                && other.sw_corner.lat < self.ne_corner.lat);
+        let lng_overlap = (self.ne_corner.lng > other.sw_corner.lng
+            && self.sw_corner.lng < other.ne_corner.lng)
+            || (other.ne_corner.lng > self.sw_corner.lng
+                && other.sw_corner.lng < self.ne_corner.lng);
+
+        lat_overlap && lng_overlap
+    }
+
+    pub fn is_valid(&self) -> bool {
+        self.ne_corner.lat <= 90.0
+            && self.ne_corner.lat >= -90.0
+            && self.sw_corner.lat <= 90.0
+            && self.sw_corner.lat >= -90.0
+            && self.ne_corner.lng <= 180.0
+            && self.ne_corner.lng >= -180.0
+            && self.sw_corner.lng <= 180.0
+            && self.sw_corner.lng >= -180.0
+            && self.ne_corner.lat >= self.sw_corner.lat
+            && self.ne_corner.lng >= self.sw_corner.lng
+    }
+
+    pub fn pad(&self, buffer_ratio: f64) -> Bounds {
+        let lat_diff = self.ne_corner.lat - self.sw_corner.lat;
+        let lng_diff = self.ne_corner.lng - self.sw_corner.lng;
+        let lat_pad = lat_diff * buffer_ratio;
+        let lng_pad = lng_diff * buffer_ratio;
+        Bounds {
+            ne_corner: Position::new(self.ne_corner.lat + lat_pad, self.ne_corner.lng - lng_pad),
+            sw_corner: Position::new(self.sw_corner.lat - lat_pad, self.sw_corner.lng + lng_pad),
+        }
+    }
+
+    pub fn equals(&self, other: Bounds) -> bool {
+        self.ne_corner == other.ne_corner && self.sw_corner == other.sw_corner
+    }
+}
+
+impl From<Bounds> for LatLngBounds {
+    fn from(value: Bounds) -> Self {
+        LatLngBounds::new(
+            &LatLng::new(value.ne_corner.lat, value.ne_corner.lng),
+            &LatLng::new(value.sw_corner.lat, value.sw_corner.lng),
+        )
+    }
+}
+
+impl From<&Bounds> for LatLngBounds {
+    fn from(value: &Bounds) -> Self {
+        LatLngBounds::new(
+            &LatLng::new(value.ne_corner.lat, value.ne_corner.lng),
+            &LatLng::new(value.sw_corner.lat, value.sw_corner.lng),
+        )
+    }
+}

--- a/leptos-leaflet/src/components/image_overlay.rs
+++ b/leptos-leaflet/src/components/image_overlay.rs
@@ -1,3 +1,4 @@
+use crate::components::bounds::Bounds;
 use crate::components::context::LeafletMapContext;
 use leptos::logging::log;
 use leptos::*;
@@ -5,7 +6,7 @@ use leptos::*;
 #[component(transparent)]
 pub fn ImageOverlay(
     #[prop(into)] url: String,
-    #[prop(into)] bounds: leaflet::LatLngBounds,
+    #[prop(into)] bounds: Bounds,
     #[prop(into, optional)] opacity: Option<MaybeSignal<f64>>,
     #[prop(into, optional)] alt: Option<MaybeSignal<String>>,
     #[prop(into, optional)] interactive: Option<MaybeSignal<bool>>,
@@ -57,7 +58,7 @@ pub fn ImageOverlay(
                 options.set_attribution(attribution.get_untracked());
             }
 
-            let map_layer = leaflet::ImageOverlay::new_with_options(&url, &bounds, &options);
+            let map_layer = leaflet::ImageOverlay::new_with_options(&url, &bounds.into(), &options);
             map_layer.add_to(&map);
             on_cleanup(move || {
                 map_layer.remove();

--- a/leptos-leaflet/src/components/mod.rs
+++ b/leptos-leaflet/src/components/mod.rs
@@ -1,3 +1,4 @@
+mod bounds;
 mod circle;
 mod context;
 mod events;
@@ -14,11 +15,13 @@ mod tile_layer_wms;
 mod tooltip;
 mod video_overlay;
 
+pub use bounds::Bounds;
 pub use circle::Circle;
 pub use context::*;
 pub use events::{
     DragEvents, LayerEvents, MapEvents, MouseEvents, MoveEvents, PopupEvents, TooltipEvents,
 };
+pub use image_overlay::ImageOverlay;
 pub use leaflet::{CircleOptions, PathOptions, PolylineOptions};
 pub use map_container::{LeafletMap, MapContainer};
 pub use marker::Marker;
@@ -30,6 +33,7 @@ pub use position::Position;
 pub use tile_layer::TileLayer;
 pub use tile_layer_wms::{TileLayerWms, TileLayerWmsEvents};
 pub use tooltip::Tooltip;
+pub use video_overlay::VideoOverlay;
 
 #[macro_export]
 macro_rules! effect_update_on_change {

--- a/leptos-leaflet/src/components/video_overlay.rs
+++ b/leptos-leaflet/src/components/video_overlay.rs
@@ -1,3 +1,4 @@
+use crate::components::bounds::Bounds;
 use crate::components::context::LeafletMapContext;
 use leptos::logging::log;
 use leptos::*;
@@ -5,7 +6,7 @@ use leptos::*;
 #[component(transparent)]
 pub fn VideoOverlay(
     #[prop(into)] url: String,
-    #[prop(into)] bounds: leaflet::LatLngBounds,
+    #[prop(into)] bounds: Bounds,
     #[prop(into, optional)] opacity: Option<MaybeSignal<f64>>,
     #[prop(into, optional)] alt: Option<MaybeSignal<String>>,
     #[prop(into, optional)] interactive: Option<MaybeSignal<bool>>,
@@ -77,7 +78,7 @@ pub fn VideoOverlay(
                 options.set_plays_inline(plays_inline.get_untracked());
             }
 
-            let map_layer = leaflet::VideoOverlay::new_with_options(&url, &bounds, &options);
+            let map_layer = leaflet::VideoOverlay::new_with_options(&url, &bounds.into(), &options);
             map_layer.add_to(&map);
             on_cleanup(move || {
                 map_layer.remove();


### PR DESCRIPTION
Implemented a new Bounds struct in bounds.rs, inspired by Leaflet's bounds functionality (see [Leaflet Bounds Reference](https://leafletjs.com/reference.html#bounds)). This struct includes methods such as .get_center() to facilitate geographical positioning and boundary calculations. These methods are straightforward and, while largely untested, are expected to function correctly due to their simplicity.

Updated the ImageOverlay and VideoOverlay components to utilize the new Bounds struct. These components are now public and can be imported without causing WASM errors, enhancing usability and integration in projects.

Removed the regex dependency from Cargo.toml. The updates I've made serve the same purpose as what the regex handled. Comprehensive testing has not been performed, but the changes are anticipated to replicate the previous functionality effectively.