### PR TITLE
Fix panic when Popup and Tooltip are used within overlay context, eg. Polygon

### DIFF
--- a/leptos-leaflet/src/components/popup.rs
+++ b/leptos-leaflet/src/components/popup.rs
@@ -24,7 +24,7 @@ pub fn Popup(
     #[prop(into, optional)] class_name: Option<MaybeSignal<String>>,
     children: Children,
 ) -> impl IntoView {
-    let map_context = use_context::<LeafletMapContext>().expect("Map context not found");
+    let map_context = use_context::<LeafletMapContext>();
     let overlay_context = use_context::<LeafletOverlayContainerContext>();
 
     // Render popup content to a html element
@@ -80,10 +80,7 @@ pub fn Popup(
             options.set_class_name(class_name.get_untracked());
         }
         if let Some(overlay_context) = overlay_context {
-            if let (Some(marker), Some(_map)) = (
-                overlay_context.container::<leaflet::Layer>(),
-                map_context.map(),
-            ) {
+            if let Some(marker) = overlay_context.container::<leaflet::Layer>() {
                 let popup = leaflet::Popup::new(&options, Some(marker.unchecked_ref()));
                 let content = inner_content.get_untracked().expect("content ref");
                 let html_view: &JsValue = content.unchecked_ref();
@@ -93,7 +90,7 @@ pub fn Popup(
                     popup.remove();
                 });
             }
-        } else if let Some(map) = map_context.map() {
+        } else if let Some(map) = map_context.expect("map context not found").map() {
             let popup =
                 leaflet::Popup::new_with_lat_lng(&position.get_untracked().into(), &options);
             let content = inner_content.get_untracked().expect("content ref");

--- a/leptos-leaflet/src/components/tooltip.rs
+++ b/leptos-leaflet/src/components/tooltip.rs
@@ -14,7 +14,7 @@ pub fn Tooltip(
     #[prop(into, optional, default=0.9.into())] opacity: MaybeSignal<f64>,
     children: Children,
 ) -> impl IntoView {
-    let map_context = use_context::<LeafletMapContext>().expect("Map context not found");
+    let map_context = use_context::<LeafletMapContext>();
     let overlay_context = use_context::<LeafletOverlayContainerContext>();
 
     let content = create_node_ref::<Div>();
@@ -27,10 +27,7 @@ pub fn Tooltip(
         options.set_opacity(opacity.get_untracked());
 
         if let Some(overlay_context) = overlay_context {
-            if let (Some(layer), Some(_map)) = (
-                overlay_context.container::<leaflet::Layer>(),
-                map_context.map(),
-            ) {
+            if let Some(layer) = overlay_context.container::<leaflet::Layer>() {
                 let tooltip = leaflet::Tooltip::new(&options, Some(layer.unchecked_ref()));
                 let content = content.get_untracked().expect("content ref");
                 tooltip.set_content(content.unchecked_ref());
@@ -39,7 +36,7 @@ pub fn Tooltip(
                     tooltip.remove();
                 });
             }
-        } else if let Some(map) = map_context.map() {
+        } else if let Some(map) = map_context.expect("Map context not found").map() {
             let tooltip =
                 leaflet::Tooltip::new_with_lat_lng(&position.get_untracked().into(), &options);
             let content = content.get_untracked().expect("content ref");


### PR DESCRIPTION
When using `Popup` and `Tooltip` in an overlay context, like a Polygon, the map context seems not to be available. `Expect`ing the map context leads to a panic in this case.

This PR fixes this behavior by moving the `expect` method further down to the place where it is really requested. In addition to that, it removes the map context as requirement from the overlay context path.