### PR TITLE
MapContainer: Adding support to disable scroll_wheel_zoom

### DIFF
--- a/leptos-leaflet/src/components/map_container.rs
+++ b/leptos-leaflet/src/components/map_container.rs
@@ -26,6 +26,9 @@ pub fn MapContainer(
     /// Wether zoom controls should be added to the map.
     #[prop(optional, default = true)]
     zoom_control: bool,
+    /// Wether mouse wheel zoom controls is enabled or disabled.
+    #[prop(optional, default = true)]
+    scroll_wheel_zoom: bool,
     /// Zoom snap of the map. Defaults to 1.0
     #[prop(optional, default = 1.0)]
     zoom_snap: f64,
@@ -73,6 +76,7 @@ pub fn MapContainer(
             let map_div = map_div.unchecked_ref::<HtmlDivElement>();
             let options = leaflet::MapOptions::new();
             options.set_zoom_control(zoom_control);
+            options.set_scroll_wheel_zoom(scroll_wheel_zoom);
             options.set_zoom(zoom);
             options.set_zoom_snap(zoom_snap);
             options.set_zoom_delta(zoom_delta);


### PR DESCRIPTION
The code in this PR is what I use now:

```rust
    view! {
      <div class="border border-gray-300 rounded-md p-1 w-full">
        <p class="text-xl font-bold mb-2">"Location"</p>
        <div class="grid grid-cols-[1fr_1fr] gap-2" style="height: 400px">
          <div class="relative rounded-md shadow-sm h-full w-full">
            <MapContainer
              style=""
              class="w-full h-full"
              center=map_center.get()
              zoom=zoom.get()
              scroll_wheel_zoom=false
              map=map.write_only()
              set_view=true
              events
            >
```

Can we put this in 0.8.3?