### PR TITLE
Zoom control fix, Component updates for leptos 0.7

### DIFF
--- a/leptos-leaflet/src/components/tile_layer_wms.rs
+++ b/leptos-leaflet/src/components/tile_layer_wms.rs
@@ -1,3 +1,4 @@
+use leptos::either::Either;
 use leptos::logging::warn;
 use leptos::prelude::*;
 use leaflet::{Map, TileLayerWms as LeafletTileLayerWms, TileLayerWmsOptions};
@@ -38,9 +39,7 @@ pub fn TileLayerWms(
             });
         }
     });
-    children.map_or(view! { <>""</> }.into_any(), |c| {
-        view! { <>{ c() }</>}.into_any()
-    })
+    children.map_or(Either::Left(view! {}), |c| Either::Right(view! { { c() } }))
 }
 
 #[component(transparent)]

--- a/leptos-leaflet/src/components/zoom.rs
+++ b/leptos-leaflet/src/components/zoom.rs
@@ -54,6 +54,14 @@ pub fn Zoom(
         control.set(Some(c));
     });
 
+    on_cleanup(move || {
+        control.with_untracked(|contr| {
+            if let Some(c) = contr {
+                c.remove();
+            }
+        });
+    });
+
     let update_position = move || {
         let position = position.get();
         let Some(c) = control.get() else {


### PR DESCRIPTION
`to_html` requires the `ssr` feature of leptos in `0.7` but this can obviously not be used on the client side. The current fix is a bit hacky by abusing the possibility of moving the DOM element from one location to another, but I do not have a better idea at the moment. I am open to other solutions.