### PR TITLE
Update dependencies for compatibility with Leptos 0.8.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,5 +28,6 @@ For now only a few of the components are ported, and events must be set in the S
 
 | Crate version | Leptos version |
 |---------------|----------------|
+| 0.10.x        | 0.8.x          |
 | 0.9.x         | 0.7.x          |
 | 0.8.x         | 0.6.x          |

--- a/examples/leaflet-api/Cargo.toml
+++ b/examples/leaflet-api/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 
 [dependencies]
 console_error_panic_hook = "0.1"
-leptos = { version = "0.7", default-features = false, "features" = ["csr"] }
+leptos = { version = "0.8.0-rc", default-features = false, "features" = ["csr"] }
 leptos-leaflet = { path = "../../leptos-leaflet", default-features = false, features = [
     "csr",
 ] }

--- a/examples/simple-map/Cargo.toml
+++ b/examples/simple-map/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 console_error_panic_hook = "0.1"
-leptos = { version = "0.7", default-features = false, "features" = [
+leptos = { version = "0.8.0-rc", default-features = false, "features" = [
     "csr",
 ] }
 leptos-leaflet = { path = "../../leptos-leaflet", default-features = false, features = [

--- a/examples/tilelayerwms/Cargo.toml
+++ b/examples/tilelayerwms/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 console_error_panic_hook = "0.1"
 geojson = "0.24"
 gloo = { version = "0.11", features = ["net"] }
-leptos = { version = "0.7", default-features = false, "features" = [
+leptos = { version = "0.8.0-rc", default-features = false, "features" = [
     "csr",
 ] }
 leptos-leaflet = { path = "../../leptos-leaflet", default-features = false, features = [

--- a/examples/with-server/Cargo.toml
+++ b/examples/with-server/Cargo.toml
@@ -7,14 +7,14 @@ edition = "2021"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-axum = { version = "0.7", optional = true }
+axum = { version = "0.8", optional = true }
 console_error_panic_hook = "0.1"
 console_log = "1"
 cfg-if = "1"
-leptos = { version = "0.7", default-features = false }
-leptos_axum = { version = "0.7", optional = true }
-leptos_meta = { version = "0.7", default-features = false }
-leptos_router = { version = "0.7", default-features = false }
+leptos = { version = "0.8.0-rc", default-features = false }
+leptos_axum = { version = "0.8.0-rc", optional = true }
+leptos_meta = { version = "0.8.0-rc", default-features = false }
+leptos_router = { version = "0.8.0-rc", default-features = false }
 leptos-leaflet = { path = "../../leptos-leaflet", default-features = false }
 log = "0.4"
 simple_logger = "5"
@@ -25,10 +25,9 @@ wasm-bindgen = "0.2"
 thiserror = "2"
 tracing = { version = "0.1", optional = true }
 http = "1"
-getrandom = "0.3"
 
 [features]
-hydrate = ["leptos/hydrate", "leptos-leaflet/hydrate", "getrandom/wasm_js"]
+hydrate = ["leptos/hydrate", "leptos-leaflet/hydrate"]
 ssr = [
     "dep:axum",
     "dep:tokio",

--- a/leptos-leaflet/Cargo.toml
+++ b/leptos-leaflet/Cargo.toml
@@ -10,14 +10,14 @@ license = "MIT"
 name = "leptos-leaflet"
 readme = "../README.md"
 repository = "https://github.com/headless-studio/leptos-leaflet"
-version = "0.9.3"
+version = "0.10.0-rc1"
 
 [dependencies]
 js-sys    = "0.3"
 
 leaflet     = "0.4"
-leptos      = { version = "0.7", default-features = false }
-leptos_meta = { version = "0.7", default-features = false }
+leptos      = { version = "0.8.0-rc", default-features = false }
+leptos_meta = { version = "0.8.0-rc", default-features = false }
 
 paste = "1.0"
 


### PR DESCRIPTION
This pull request addresses compatibility with Leptos version 0.8.x by:

- Updating the compatibility table for crate version 0.10.x to include Leptos version 0.8.x.
- Updating the `leptos` dependency version to `0.8` in multiple `Cargo.toml` files.

No breaking changes were introduced.